### PR TITLE
fix: MyPage 높이 계산 로직 수정

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -19,7 +19,9 @@ const Layout = ({ children }: LayoutProps) => {
     `(min-width: ${RESPONSIVE_BREAKPOINT.desktop}px)`,
   );
   const { keyword } = useKeywordStore();
-  const mainHeight = keyword ? "h-[calc(100vh-100px)]" : "h-full";
+  const isMyPage = location.pathname === "/mypage";
+
+  const mainHeight = isMyPage || keyword ? "h-[calc(100vh-100px)]" : "h-full";
 
   return (
     <>


### PR DESCRIPTION
## 🛠️ 작업 내용
mainHeight 계산할 때 isMyPage(현재 주소가 '/mypage' 인지 검사) 포함하도록 수정

## 📱 작업 화면
https://github.com/user-attachments/assets/9f54300b-08c2-40bf-b97d-908e749015c7